### PR TITLE
Prompt tuning

### DIFF
--- a/public/local/data/api/chat-session.js
+++ b/public/local/data/api/chat-session.js
@@ -5,7 +5,11 @@ import { getProviderCapabilities } from "./llm.js";
 import { estimateTokens } from "../util.js";
 import { createHandler as createChromeHandler } from "./providers/chrome.js";
 import { createHandler as createWebLlmHandler } from "./providers/web-llm.js";
-import { buildBasePrompts, BASE_TOKEN_ESTIMATE } from "./chat.js";
+import {
+  buildBasePrompts,
+  withCitationReminder,
+  BASE_TOKEN_ESTIMATE,
+} from "./chat.js";
 import { performRagSearch, reduceContext as ragReduceContext } from "./rag.js";
 import {
   getModelCfg,
@@ -138,15 +142,19 @@ const buildUsageMessage = ({
 }) => {
   const queryTokens = estimateTokens(userMessage);
   const tokenBreakdown = getTokenBreakdown(state);
+  // Use the base-prompt estimate captured at context-build time — it already reflects the
+  // model's tier (LEAN vs FULL), unlike the always-FULL BASE_TOKEN_ESTIMATE constant.
+  const basePromptTokens =
+    tokenBreakdown?.basePromptTokens ?? BASE_TOKEN_ESTIMATE;
   const contextTokens = tokenBreakdown
     ? {
-        basePromptTokens: BASE_TOKEN_ESTIMATE,
+        basePromptTokens,
         queryTokens,
         chunksTokens: tokenBreakdown.chunksTokens,
         chunkCount: getChunkCount(state),
         historyTokens,
         totalTokens:
-          BASE_TOKEN_ESTIMATE +
+          basePromptTokens +
           tokenBreakdown.chunksTokens +
           historyTokens +
           queryTokens,
@@ -222,6 +230,7 @@ export const createChatSession = ({
             model,
             systemContext: getContext(state),
             temperature,
+            maxTokens,
           })
         : await createWebLlmHandler({
             model,
@@ -237,9 +246,9 @@ export const createChatSession = ({
    * Build messages for web-llm (stateless provider).
    */
   const buildMessages = (userMessage) => [
-    ...buildBasePrompts(getContext(state), userMessage),
+    ...buildBasePrompts(getContext(state), userMessage, { maxTokens }),
     ...state.history,
-    { role: "user", content: userMessage },
+    { role: "user", content: withCitationReminder(userMessage) },
   ];
 
   /**
@@ -259,7 +268,12 @@ export const createChatSession = ({
     }
 
     const handler = await ensureHandler();
-    const input = provider === "webLlm" ? buildMessages(query) : query;
+    // web-llm gets the full messages array (reminder applied inside buildMessages); Chrome takes a
+    // raw user string, so apply the citation reminder here for the Prompt + Writer paths.
+    const input =
+      provider === "webLlm"
+        ? buildMessages(query)
+        : withCitationReminder(query);
     let firstTokenTime = null;
 
     for await (const event of handler.sendMessage(input)) {

--- a/public/local/data/api/chat.js
+++ b/public/local/data/api/chat.js
@@ -11,10 +11,28 @@ import {
   THROW_ON_TOKEN_LIMIT,
 } from "../../../config.js";
 import { getPost } from "./posts.js";
-import { buildSystemPrompt, MAX_SYSTEM_PROMPT } from "./prompts.js";
+import {
+  buildSystemPrompt,
+  MAX_SYSTEM_PROMPT,
+  LEAN_SYSTEM_PROMPT,
+  isLeanTier,
+} from "./prompts.js";
 
 // Set to true to enable detailed token debugging in console
 const DEBUG_TOKENS = false;
+
+// Short reminder appended to the user turn for recency — small models weight the last tokens most.
+// The UI stores the raw query separately, so the displayed question is unaffected.
+export const USER_CITATION_REMINDER =
+  "\n\n(Cite at least one source inline using only the allowed links; use each link at most once and never repeat one.)";
+
+/**
+ * Append the citation recency reminder to a user message.
+ * @param {string} query - The user's message
+ * @returns {string}
+ */
+export const withCitationReminder = (query) =>
+  `${query}${USER_CITATION_REMINDER}`;
 
 /**
  * Build base system prompts with RAG context.
@@ -22,21 +40,49 @@ const DEBUG_TOKENS = false;
  * Does NOT include the final user query - that's added separately.
  * @param {string} context - RAG context (XML chunks)
  * @param {string} [query=""] - User query for conditional prompt sections
+ * @param {Object} [options]
+ * @param {number} [options.maxTokens] - Model context window; selects LEAN vs FULL system prompt
  * @returns {Array<{role: string, content: string}>}
  */
-export const buildBasePrompts = (context = "", query = "") => {
-  // Extract links from context.
+export const buildBasePrompts = (
+  context = "",
+  query = "",
+  { maxTokens } = {},
+) => {
+  // Extract links from context, one entry per unique URL.
   const linkPattern =
     /<CHUNK><URL>([^<]+)<\/URL><TITLE>([^<]+)<\/TITLE><CONTENT>/g;
-  let links = "";
+  const seenUrls = new Set();
+  /** @type {Array<{url: string, title: string}>} */
+  const entries = [];
   for (const match of context.matchAll(linkPattern)) {
-    links += `- [${match[2]}](${match[1]})\n`;
+    const [, url, title] = match;
+    if (seenUrls.has(url)) continue;
+    seenUrls.add(url);
+    entries.push({ url, title });
   }
+
+  // Disambiguate identical titles across different URLs so no two allowed links share link text
+  // (e.g. two PUMA posts both titled "PUMA e-Commerce Platform"). Append a human-readable hint
+  // derived from the URL's last path segment to the colliding ones.
+  const titleCounts = entries.reduce((counts, { title }) => {
+    counts[title] = (counts[title] ?? 0) + 1;
+    return counts;
+  }, /** @type {Record<string, number>} */ ({}));
+  const slugHint = (url) =>
+    url.replace(/\/+$/, "").split("/").pop().replace(/[-_]+/g, " ").trim();
+  const links = entries
+    .map(({ url, title }) => {
+      const text =
+        titleCounts[title] > 1 ? `${title} — ${slugHint(url)}` : title;
+      return `- [${text}](${url})`;
+    })
+    .join("\n");
 
   return [
     {
       role: "system",
-      content: buildSystemPrompt(query),
+      content: buildSystemPrompt(query, { maxTokens }),
     },
     {
       role: "assistant",
@@ -44,7 +90,7 @@ export const buildBasePrompts = (context = "", query = "") => {
     },
     {
       role: "assistant",
-      content: `You may only choose links from the following list of urls from the <CHUNKS />: ${links}`,
+      content: `These are the ONLY links you may cite, each at most once and inline where it fits. You MUST cite at least one. Use the exact link text shown:\n${links}`,
     },
   ];
 };
@@ -61,19 +107,24 @@ const createMessages = ({ query, context = "" }) => [
   ...buildBasePrompts(context, query),
   {
     role: "user",
-    content: query,
+    content: withCitationReminder(query),
   },
 ];
 
-// Use MAX_SYSTEM_PROMPT (all conditional sections) for token envelope estimation.
-// Over-reserves ~78 tokens worst case when conditional sections don't match.
-export const BASE_TOKEN_ESTIMATE = estimateTokens(
-  JSON.stringify(
-    createMessages({ query: "" }).map((m) =>
-      m.role === "system" ? { ...m, content: MAX_SYSTEM_PROMPT } : m,
+// Base-prompt token envelope, estimated per tier by overriding the system message with the
+// corresponding worst-case system prompt. FULL uses MAX_SYSTEM_PROMPT (all conditional sections);
+// LEAN uses LEAN_SYSTEM_PROMPT. buildContextFromChunks picks the estimate matching the model's tier.
+const estimateBaseTokens = (systemPrompt) =>
+  estimateTokens(
+    JSON.stringify(
+      createMessages({ query: "" }).map((m) =>
+        m.role === "system" ? { ...m, content: systemPrompt } : m,
+      ),
     ),
-  ),
-);
+  );
+
+export const BASE_TOKEN_ESTIMATE = estimateBaseTokens(MAX_SYSTEM_PROMPT);
+export const LEAN_BASE_TOKEN_ESTIMATE = estimateBaseTokens(LEAN_SYSTEM_PROMPT);
 
 /**
  * Build XML context string from search chunks with token limiting.
@@ -98,6 +149,10 @@ export const buildContextFromChunks = async ({
 }) => {
   const modelCfg = getModelCfg({ provider, model });
   const maxTokens = modelCfg.maxTokens;
+  // Budget chunks against the base prompt this model actually gets (LEAN vs FULL).
+  const baseTokenEstimate = isLeanTier(maxTokens)
+    ? LEAN_BASE_TOKEN_ESTIMATE
+    : BASE_TOKEN_ESTIMATE;
   const cushion = forMultiTurn
     ? getMultiTurnCushion(maxTokens)
     : TOKEN_CUSHION_CHAT;
@@ -114,7 +169,7 @@ export const buildContextFromChunks = async ({
   // For Chrome, could use measureContextUsage() for actual counts, but requires
   // creating a session first. For now, estimates provide reasonable approximation.
   const queryTokens = estimateTokens(query);
-  let totalContextTokensEst = BASE_TOKEN_ESTIMATE + queryTokens;
+  let totalContextTokensEst = baseTokenEstimate + queryTokens;
 
   if (DEBUG_TOKENS) {
     const tokensForChunks = maxContextTokens - totalContextTokensEst;
@@ -134,7 +189,7 @@ export const buildContextFromChunks = async ({
             ? MULTI_TURN_CONTEXT_RATIO
             : "N/A (skipped)",
           maxContextTokens,
-          basePromptTokens: BASE_TOKEN_ESTIMATE,
+          basePromptTokens: baseTokenEstimate,
           queryTokens,
           startingTotal: totalContextTokensEst,
           tokensForChunks,
@@ -274,8 +329,7 @@ export const buildContextFromChunks = async ({
     .join("");
 
   // Calculate granular token breakdown
-  const chunksTokens =
-    totalContextTokensEst - BASE_TOKEN_ESTIMATE - queryTokens;
+  const chunksTokens = totalContextTokensEst - baseTokenEstimate - queryTokens;
 
   return {
     context,
@@ -285,7 +339,7 @@ export const buildContextFromChunks = async ({
     tokenEstimate: totalContextTokensEst,
     // Granular token breakdown for UI display
     tokenBreakdown: {
-      basePromptTokens: BASE_TOKEN_ESTIMATE,
+      basePromptTokens: baseTokenEstimate,
       queryTokens,
       chunksTokens,
       totalTokens: totalContextTokensEst,
@@ -326,7 +380,8 @@ export const rebuildContextWithLimit = async ({
 if (DEBUG_TOKENS) {
   // eslint-disable-next-line no-undef
   console.log(
-    "DEBUG(TOKENS) chat.js - BASE_TOKEN_ESTIMATE:",
+    "DEBUG(TOKENS) chat.js - BASE_TOKEN_ESTIMATE (full / lean):",
     BASE_TOKEN_ESTIMATE,
+    LEAN_BASE_TOKEN_ESTIMATE,
   );
 }

--- a/public/local/data/api/chat.js
+++ b/public/local/data/api/chat.js
@@ -24,7 +24,7 @@ const DEBUG_TOKENS = false;
 // Short reminder appended to the user turn for recency — small models weight the last tokens most.
 // The UI stores the raw query separately, so the displayed question is unaffected.
 export const USER_CITATION_REMINDER =
-  "\n\n(Cite at least one source inline using only the allowed links; use each link at most once and never repeat one.)";
+  "\n\n(Cite sources inline from the allowed links only — each at most once, never repeated. If none are relevant, say you don't have enough information; never invent a source.)";
 
 /**
  * Append the citation recency reminder to a user message.
@@ -79,6 +79,12 @@ export const buildBasePrompts = (
     })
     .join("\n");
 
+  // Only mandate a citation when links actually exist; otherwise an impossible instruction
+  // invites hallucinated sources. With no links, steer toward the "not enough info" path.
+  const linkDirective = links
+    ? `These are the ONLY links you may cite, each at most once and inline where it fits. You MUST cite at least one. Use the exact link text shown:\n${links}`
+    : `No sources were retrieved for this question. Do NOT cite or invent any links — tell the user you don't have enough information to answer.`;
+
   return [
     {
       role: "system",
@@ -90,7 +96,7 @@ export const buildBasePrompts = (
     },
     {
       role: "assistant",
-      content: `These are the ONLY links you may cite, each at most once and inline where it fits. You MUST cite at least one. Use the exact link text shown:\n${links}`,
+      content: linkDirective,
     },
   ];
 };

--- a/public/local/data/api/prompts.js
+++ b/public/local/data/api/prompts.js
@@ -1,72 +1,70 @@
 // Prompt constants and builders for Joyce's RAG-based chat.
-// Adapted from web-agents patterns with conditional topic guidance.
+//
+// Two tiers, selected by the model's context budget (see buildSystemPrompt):
+// - LEAN: a compact core for small-context models (< LEAN_PROMPT_MAX_TOKENS). Smaller prompt =
+//   more room for RAG chunks, and less instruction dilution for tiny models.
+// - FULL: the lean core PLUS extra guidance (URL normalization, conditional topic sections) and a
+//   few-shot example. Used for larger-context models that can afford it.
+//
+// Citing at least one source is MANDATORY on every answer in both tiers — it lives in the lean core.
+
+import { LEAN_PROMPT_MAX_TOKENS } from "../../../config.js";
 
 // ============================================================================
-// Identity & Brand
+// Lean core (always included, both tiers)
 // ============================================================================
 
-const NEARFORM_IDENTITY = `You are a helpful assistant for Nearform. Nearform is a global software consultancy, deeply rooted in open source — with over a decade of contributions to the open source ecosystem (Node.js, React, React Native) — that builds mission-critical digital products for ambitious enterprises. Nearform has expertise in frontend, backend, mobile (React Native), devops, cloud, AI, product/design, and more.`;
+const NEARFORM_IDENTITY = `You are a helpful assistant for Nearform, a global software consultancy rooted in open source (Node.js, React, React Native) that builds mission-critical products for ambitious enterprises. Expertise spans frontend, backend, mobile (React Native), devops, cloud, AI, and product/design.`;
 
-const BRAND_RULES = `## Brand Rules
-- Nearform has acquired Formidable. Replace "Formidable", "Formidable Labs", or "Nearform Commerce" with "Nearform".
-- Always use "Nearform" (lowercase 'f'), never "NearForm". Even if sources use "NearForm", answer with "Nearform".`;
+const SOURCE_MANDATE = `Every answer MUST cite at least one real source. Use only facts and URLs from the retrieved CHUNKs; every URL you cite must appear verbatim in a CHUNK.`;
 
-const CLIENT_MAP = `## Nearform Clients
-- "RTD" is "Regional Transportation District" of Denver, Colorado.`;
+const BRAND_RULES = `## Brand
+- Nearform acquired Formidable / Formidable Labs / Nearform Commerce — call all of these "Nearform".
+- Always spell it "Nearform" (never "NearForm"), even when sources differ.`;
 
-const TERMINOLOGY = `## Terminology
-Use ONLY these expansions for Nearform acronyms. Do NOT invent or substitute other meanings:
-- BMAD = "Breakthrough Method for Agile AI-Driven Development" (never "Business Model, Architecture, Design" or any other expansion)
-- AINE = "AI-Native Engineering"
-- SDD = "Spec-Driven Development"
-- MCP = "Model Context Protocol"
-- RTD = "Regional Transportation District" (Denver, Colorado transit agency — never "Real-Time Data" or any other expansion)`;
+const TERMINOLOGY = `## Terminology (use ONLY these expansions; never invent others)
+- BMAD = Breakthrough Method for Agile AI-Driven Development
+- AINE = AI-Native Engineering
+- SDD = Spec-Driven Development
+- MCP = Model Context Protocol
+- RTD = Regional Transportation District (Denver, Colorado transit agency)`;
 
-// ============================================================================
-// Context & Citation Rules
-// ============================================================================
+const CONTEXT_FORMAT = `## Context
+Content is provided as XML <CHUNK> elements (parts of Nearform web pages), each with <URL>, <TITLE>, and <CONTENT>. Answer from <CONTENT>; earlier chunks are higher priority. Refer to them as "sources" or "articles" — never say "chunk"/"context". If nothing relevant is provided, say you don't have enough information.`;
 
-const CONTEXT_FORMAT = `## Context Format
-Content is provided as XML CHUNKs, which are PARTS of full Nearform web pages. Each <CHUNK> contains:
-- <URL>: Reference link
-- <TITLE>: Post title
-- <CONTENT>: Text content`;
-
-const CONTEXT_USAGE = `## How to Use Context
-- When answering refer ONLY to "citations", "articles", "sources".
-- When answering, DO NOT refer to "chunks", "CHUNKS", or "context" or any of the internal provided assistant content context.
-- Use information from <CHUNK><CONTENT> wherever possible in your answers.
-- Try to use information from earlier chunks in your answers. They are in priority order.
-- If no relevant information exists, state that you don't have enough information to answer.`;
-
-const CITATION_RULES = `## Citation Rules
-- If asked for "links", "articles", "sources", "citations", or "references", you SHOULD reference links from context <CHUNKS />.
-- Do NOT add links unless they appear in <CHUNK><URL>.
-- You MUST cite sources as markdown links. The format is EXACTLY: [Title](URL) — the ] must come BEFORE the (.
-  CORRECT: [My Article](https://nearform.com/insights/my-article)
-  WRONG:   [My Article (https://nearform.com/insights/my-article)]
-- Each URL may appear at most ONCE in your answer. Chunks may repeat URLs; do not duplicate links.
-- Assistant provides a markdown list of acceptably formatted links to use. Use ONLY those links for responses.`;
-
-const URL_NORMALIZATION = `## URL Normalization
-When citing Nearform URLs:
-- Do NOT hallucinate URLs. Only cite URLs explicitly present in context.
-- URLs must begin with "https://nearform.com/" — remove "www." or "commerce." prefixes.
-- Valid path segments: /insights/, /digital-community/, /work/, /services/
-- Replace "/blog/" with "/insights/". For unknown paths, default to "/insights/".`;
+const CITATION_RULES = `## Citing Sources (REQUIRED ON EVERY ANSWER)
+- EVERY answer MUST cite at least one source. Never answer without a source.
+- Cite ONLY links from the provided allowed-links list. Never invent or alter a URL or its link text.
+- Cite inline: put the source as a markdown link right next to the claim it supports. Format EXACTLY: [Title](URL) — the ] comes immediately before the (.
+- Use each URL AT MOST ONCE in the entire answer. Never repeat the same link.
+- Do NOT add a separate "Sources" or "References" list at the end. Cite inline only.
+- If no allowed link is relevant, say you don't have enough information — never fabricate a source.`;
 
 // ============================================================================
-// Conditional Topic Guidance
+// Full-tier additions
 // ============================================================================
+
+const CITATION_EXAMPLE = `## Example (inline only; each link used once; no trailing list)
+Allowed links:
+- [PUMA — scaling across the globe](https://nearform.com/work/puma-scaling-across-the-globe)
+- [PUMA e-Commerce Platform](https://nearform.com/work/puma)
+
+Q: How did Nearform scale PUMA's platform globally?
+A: Nearform unified PUMA's per-region storefronts onto a single headless platform [PUMA — scaling across the globe](https://nearform.com/work/puma-scaling-across-the-globe), abstracting regional differences behind a GraphQL API with server-side rendering and caching [PUMA e-Commerce Platform](https://nearform.com/work/puma).`;
+
+const URL_NORMALIZATION = `## URL Normalization (when citing)
+- Normalize to "https://nearform.com/..." — remove "www." or "commerce." prefixes.
+- Valid path segments: /insights/, /digital-community/, /work/, /services/.
+- Replace "/blog/" with "/insights/"; for unknown paths default to "/insights/".`;
 
 const AINE_GUIDANCE = `## AI-Native Engineering
-Nearform is a leader in AI-native engineering (AINE), embedding AI responsibly into the software delivery lifecycle to help organizations ship faster, safer, and smarter. Nearform's expertise includes: AI-powered development workflows, MCP/WebMCP integrations, AI-native IDE adoption (Cursor, GitHub Copilot, Claude Code, Windsurf), BMAD methodology, spec-driven development (SDD), agentic coding, and helping teams integrate AI into their software delivery.`;
+Nearform is a leader in AI-native engineering (AINE), embedding AI responsibly into the software delivery lifecycle so organizations ship faster, safer, and smarter. Strengths: AI-powered development workflows, MCP/WebMCP integrations, AI-native IDE adoption (Cursor, GitHub Copilot, Claude Code, Windsurf), BMAD methodology, spec-driven development (SDD), and agentic coding.`;
 
 const ECOMMERCE_GUIDANCE = `## E-Commerce Expertise
-Nearform has deep e-commerce expertise including: high-traffic storefront builds (PUMA, Kernel, RBI/Restaurant Brands International, RTD/Regional Transportation District), headless/composable commerce architectures, checkout and payment integrations, and performance optimization for retail platforms.`;
+Nearform has deep e-commerce expertise: high-traffic storefronts (PUMA, Kernel, RBI/Restaurant Brands International, RTD/Regional Transportation District), headless/composable commerce architectures, checkout and payment integrations, and retail performance optimization.`;
 
 // ============================================================================
-// Topic Matchers
+// Topic Matchers (conditional, full tier only)
 // ============================================================================
 
 const AINE_REGEX =
@@ -79,39 +77,73 @@ export const matchesAine = (query) => AINE_REGEX.test(query);
 export const matchesEcommerce = (query) => ECOMMERCE_REGEX.test(query);
 
 // ============================================================================
-// Prompt Builder
+// Tier selection
 // ============================================================================
 
 /**
- * Build the system prompt, conditionally appending topic guidance.
- * @param {string} [query=""] - User query for conditional section matching
+ * Whether a model's context budget puts it on the LEAN tier.
+ * Unknown/unbounded budgets (null, undefined, Infinity) → FULL.
+ * @param {number} [maxTokens] - Model's context window
+ * @returns {boolean}
+ */
+export const isLeanTier = (maxTokens) =>
+  Number.isFinite(maxTokens) && maxTokens < LEAN_PROMPT_MAX_TOKENS;
+
+// ============================================================================
+// Prompt Builder
+// ============================================================================
+
+const LEAN_CORE = [
+  NEARFORM_IDENTITY,
+  SOURCE_MANDATE,
+  BRAND_RULES,
+  TERMINOLOGY,
+  CONTEXT_FORMAT,
+  CITATION_RULES,
+];
+
+/**
+ * Assemble a system prompt for an explicit tier.
+ * @param {string} query - User query for conditional section matching (full tier only)
+ * @param {boolean} lean - Whether to build the LEAN core only
  * @returns {string}
  */
-export const buildSystemPrompt = (query = "") => {
-  const sections = [
-    NEARFORM_IDENTITY,
-    `All responses must only use facts and URLs from retrieved CHUNKs. URLs must be real and explicitly present in the CHUNKs.`,
-    BRAND_RULES,
-    CLIENT_MAP,
-    TERMINOLOGY,
-    CONTEXT_FORMAT,
-    CONTEXT_USAGE,
-    CITATION_RULES,
-    URL_NORMALIZATION,
-  ];
+const assembleSystemPrompt = (query, lean) => {
+  const sections = [...LEAN_CORE];
 
-  if (query && matchesAine(query)) {
-    sections.push(AINE_GUIDANCE);
-  }
-  if (query && matchesEcommerce(query)) {
-    sections.push(ECOMMERCE_GUIDANCE);
+  if (!lean) {
+    // FULL tier: reinforce citing with an example, add URL hygiene + matched topic guidance.
+    sections.push(CITATION_EXAMPLE, URL_NORMALIZATION);
+    if (query && matchesAine(query)) {
+      sections.push(AINE_GUIDANCE);
+    }
+    if (query && matchesEcommerce(query)) {
+      sections.push(ECOMMERCE_GUIDANCE);
+    }
   }
 
   return sections.join("\n\n");
 };
 
 /**
- * Maximum system prompt (all conditional sections included).
- * Used for token estimation envelope.
+ * Build the system prompt for a model, conditionally appending full-tier guidance.
+ * @param {string} [query=""] - User query for conditional section matching (full tier only)
+ * @param {Object} [options]
+ * @param {number} [options.maxTokens] - Model context window; selects LEAN vs FULL
+ * @returns {string}
  */
-export const MAX_SYSTEM_PROMPT = buildSystemPrompt("ai-native e-commerce");
+export const buildSystemPrompt = (query = "", { maxTokens } = {}) =>
+  assembleSystemPrompt(query, isLeanTier(maxTokens));
+
+/**
+ * Maximum (FULL) system prompt with all conditional sections — worst-case token envelope.
+ */
+export const MAX_SYSTEM_PROMPT = assembleSystemPrompt(
+  "ai-native e-commerce",
+  false,
+);
+
+/**
+ * LEAN system prompt — token envelope for small-context models.
+ */
+export const LEAN_SYSTEM_PROMPT = assembleSystemPrompt("", true);

--- a/public/local/data/api/prompts.js
+++ b/public/local/data/api/prompts.js
@@ -16,7 +16,7 @@ import { LEAN_PROMPT_MAX_TOKENS } from "../../../config.js";
 
 const NEARFORM_IDENTITY = `You are a helpful assistant for Nearform, a global software consultancy rooted in open source (Node.js, React, React Native) that builds mission-critical products for ambitious enterprises. Expertise spans frontend, backend, mobile (React Native), devops, cloud, AI, and product/design.`;
 
-const SOURCE_MANDATE = `Every answer MUST cite at least one real source. Use only facts and URLs from the retrieved CHUNKs; every URL you cite must appear verbatim in a CHUNK.`;
+const SOURCE_MANDATE = `Ground every answer in the retrieved CHUNKs and cite at least one source whenever you use them; only cite URLs that appear verbatim in a CHUNK. If no CHUNK is relevant, say you don't have enough information — never fabricate facts or sources.`;
 
 const BRAND_RULES = `## Brand
 - Nearform acquired Formidable / Formidable Labs / Nearform Commerce — call all of these "Nearform".
@@ -32,13 +32,13 @@ const TERMINOLOGY = `## Terminology (use ONLY these expansions; never invent oth
 const CONTEXT_FORMAT = `## Context
 Content is provided as XML <CHUNK> elements (parts of Nearform web pages), each with <URL>, <TITLE>, and <CONTENT>. Answer from <CONTENT>; earlier chunks are higher priority. Refer to them as "sources" or "articles" — never say "chunk"/"context". If nothing relevant is provided, say you don't have enough information.`;
 
-const CITATION_RULES = `## Citing Sources (REQUIRED ON EVERY ANSWER)
-- EVERY answer MUST cite at least one source. Never answer without a source.
+const CITATION_RULES = `## Citing Sources (REQUIRED whenever you use the sources)
+- If any allowed link is relevant, you MUST cite at least one. Never present sourced claims without a citation.
 - Cite ONLY links from the provided allowed-links list. Never invent or alter a URL or its link text.
 - Cite inline: put the source as a markdown link right next to the claim it supports. Format EXACTLY: [Title](URL) — the ] comes immediately before the (.
 - Use each URL AT MOST ONCE in the entire answer. Never repeat the same link.
 - Do NOT add a separate "Sources" or "References" list at the end. Cite inline only.
-- If no allowed link is relevant, say you don't have enough information — never fabricate a source.`;
+- If no allowed link is relevant (or none were provided), say you don't have enough information — never fabricate a source.`;
 
 // ============================================================================
 // Full-tier additions

--- a/public/local/data/api/providers/chrome.js
+++ b/public/local/data/api/providers/chrome.js
@@ -161,9 +161,15 @@ export const getCapabilities = (model) => ({
  * @param {string} options.model - Model ID (determines prompt vs writer API)
  * @param {string} options.systemContext - RAG context for system prompt
  * @param {number} options.temperature - Sampling temperature
+ * @param {number} [options.maxTokens] - Model context window; selects LEAN vs FULL system prompt
  * @returns {Promise<Object>} Handler with sendMessage(userMessage) and destroy()
  */
-export const createHandler = async ({ model, systemContext, temperature }) => {
+export const createHandler = async ({
+  model,
+  systemContext,
+  temperature,
+  maxTokens,
+}) => {
   const apiType = getApiType(model);
   const progressCallback = modelState.get(model)?.progressCallback ?? null;
 
@@ -172,9 +178,10 @@ export const createHandler = async ({ model, systemContext, temperature }) => {
       systemContext,
       temperature,
       progressCallback,
+      maxTokens,
     });
   } else {
-    return createWriterHandler({ systemContext, progressCallback });
+    return createWriterHandler({ systemContext, progressCallback, maxTokens });
   }
 };
 
@@ -185,6 +192,7 @@ const createPromptHandler = async ({
   systemContext,
   temperature,
   progressCallback,
+  maxTokens,
 }) => {
   const status = await checkAvailability("prompt");
   if (!status.available && !status.downloading) {
@@ -194,7 +202,7 @@ const createPromptHandler = async ({
     );
   }
 
-  const initialPrompts = buildBasePrompts(systemContext);
+  const initialPrompts = buildBasePrompts(systemContext, "", { maxTokens });
 
   const session = await wrap(
     "chrome.prompt.create",
@@ -267,7 +275,11 @@ const createPromptHandler = async ({
 /**
  * Create a Writer API handler (single-turn).
  */
-const createWriterHandler = async ({ systemContext, progressCallback }) => {
+const createWriterHandler = async ({
+  systemContext,
+  progressCallback,
+  maxTokens,
+}) => {
   const status = await checkAvailability("writer");
   if (!status.available && !status.downloading) {
     throw new Error(
@@ -276,7 +288,7 @@ const createWriterHandler = async ({ systemContext, progressCallback }) => {
     );
   }
 
-  const basePrompts = buildBasePrompts(systemContext);
+  const basePrompts = buildBasePrompts(systemContext, "", { maxTokens });
   const fullSharedContext = basePrompts.map((m) => m.content).join("\n\n");
 
   return {

--- a/public/local/data/api/providers/web-llm.js
+++ b/public/local/data/api/providers/web-llm.js
@@ -6,7 +6,11 @@ import {
   deleteModelAllInfoInCache,
   prebuiltAppConfig,
 } from "@mlc-ai/web-llm";
-import { DEFAULT_CHAT_MODEL } from "../../../../config.js";
+import {
+  DEFAULT_CHAT_MODEL,
+  WEB_LLM_FREQUENCY_PENALTY,
+  WEB_LLM_PRESENCE_PENALTY,
+} from "../../../../config.js";
 import {
   wrap,
   breadcrumb,
@@ -272,6 +276,9 @@ export const createHandler = async ({
             messages,
             temperature,
             max_tokens: maxOutputTokens,
+            // Curb small-model runaway repetition / missing EOS. See WEB_LLM_*_PENALTY in config.
+            frequency_penalty: WEB_LLM_FREQUENCY_PENALTY,
+            presence_penalty: WEB_LLM_PRESENCE_PENALTY,
             stream: true,
             stream_options: { include_usage: true },
             ...(extraBody && { extra_body: extraBody }),

--- a/public/shared-config.js
+++ b/public/shared-config.js
@@ -44,6 +44,17 @@ export const TOKEN_CUSHION_CHAT = 512; // 250 ok for web-llm
 export const TOKEN_CUSHION_EMBEDDINGS = 25;
 export const MAX_OUTPUT_TOKENS = 1024; // Limit LLM response length
 
+// web-llm sampling penalties (OpenAI-style, range -2..2). Small models (e.g. SmolLM2, TinyLlama)
+// are prone to looping / never emitting EOS; a modest penalty curbs runaway repetition. Capable
+// models are largely unaffected at these levels. Tune here.
+export const WEB_LLM_FREQUENCY_PENALTY = 0.4;
+export const WEB_LLM_PRESENCE_PENALTY = 0.2;
+
+// System-prompt tier split. Models whose context window is below this get the LEAN system
+// prompt (smaller, so more room for RAG chunks); models at/above it get the FULL prompt
+// (lean core + extra guidance + a few-shot example). See buildSystemPrompt in prompts.js.
+export const LEAN_PROMPT_MAX_TOKENS = 4096;
+
 // When false: token limit checks warn and proceed, letting real API errors occur
 // When true: token limit checks throw errors immediately (current behavior)
 export const THROW_ON_TOKEN_LIMIT = false;
@@ -118,17 +129,23 @@ const WEB_LLM_CHAT_DESKTOP = [
 // Mobile (iOS/Android): a lighter SmolLM2 → TinyLlama → Llama ladder, all q4f16_1 and <900MB, so the
 // out-of-the-box picks load without risking a Safari tab kill. Larger models stay reachable via the
 // models table; these are just the flagged defaults.
+//
+// The default is TinyLlama-1.1B: at 2K context it lands on the LEAN prompt tier, but even so it is
+// closer to correct (grounding, citing, stopping) than the 360M option. SmolLM2-360M stays as the
+// lightest "Fast" pick for the most memory-constrained devices, but it is below the floor for grounded
+// RAG — it won't reliably cite sources, honor brand casing, or stay on-context, regardless of prompt.
+// For citation-grade answers prefer TinyLlama-1.1B+ (or desktop Qwen/Llama, or Chrome's gemini-nano).
 const WEB_LLM_CHAT_MOBILE = [
   {
     model: "SmolLM2-360M-Instruct-q4f16_1-MLC",
     modelShortName: "SmolLM2-360M",
     shortOption: "Fast",
-    default: !CHROME_ANY_API_POSSIBLE,
   },
   {
     model: "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC",
     modelShortName: "TinyLlama-1.1B",
     shortOption: "Better",
+    default: !CHROME_ANY_API_POSSIBLE,
   },
   {
     model: "Llama-3.2-1B-Instruct-q4f16_1-MLC",


### PR DESCRIPTION
- Add LEAN/FULL system-prompt tiering keyed off model context window, and budget RAG chunks against the correct tier’s base-prompt estimate.
- Append a short “cite inline” recency reminder to the user turn, and improve allowed-links generation (dedupe URLs + disambiguate duplicate titles).
- Add web-llm frequency/presence penalties and change the mobile default web-llm model to TinyLlama-1.1B.